### PR TITLE
Update Sorting table

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -67,7 +67,7 @@
       <th>Algorithm</th>
       <th>Data Structure</th>
       <th colspan="3">Time Complexity</th>
-      <th colspan="3">Space Complexity</th>
+      <th colspan="3">Worst Case Auxiliary Space Complexity</th>
     </tr>
     <tr>
       <th></th>


### PR DESCRIPTION
Colors:
1. In the "Best" you're showing O(n log(n)) as yellow but O(n) as red; O(n) should be green.
2. In "Average" and "Worst" you're showing O(n log(n)) as yellow but it's the best you can do so I think green makes more sense.
3. In "Space Complexity" you are showing both O(1) and O(log(n)) as green, O(log(n)) should be yellow.

I also added heapsort. It has the same time comp'exity as mergesort but O(1) space complexity.

The "Space Complexity" column clearly means different things between the sorting and and data structures tables. I've updated the sorting table's column header to "Worst Case Auxiliary Space Complexity" which is what it actually describes.
