### PR TITLE
DFS and BFS for graphs

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -19,19 +19,19 @@
   <tbody>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Depth-first_search">Depth First Search (DFS)</a></td>
-      <td>Tree</td>
+      <td>Graph of |V| vertices and |E| edges</td>
       <td><code class="green">O(1)</code></td>
       <td><code>-</code></td>
-      <td><code class="red" rel="tooltip" title="b = branching factor, d = depth of the tree">O(b^d)</code></td>
-      <td><code class="green" rel="tooltip" title="|V| means the number of vertices in the longest path of the tree">O(|V|)</code></td>
+      <td><code class="green">O(|E| + |V|)</code></td>
+      <td><code class="green">O(|V|)</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Breadth-first_search">Breadth First Search (BFS)</a></td>
-      <td>Tree</td>
+      <td>Graph of |V| vertices and |E| edges</td>
       <td><code class="green">O(1)</code></td>
       <td><code>-</code></td>
-      <td><code class="red" rel="tooltip" title="b = branching factor, d = depth of the tree">O(b^d)</code></td>
-      <td><code class="red" rel="tooltip" title="b = branching factor, d = depth of the tree">O(b^d)</code></td>
+      <td><code class="green">O(|E| + |V|)</code></td>
+      <td><code class="green">O(|V|)</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Binary_search_algorithm">Binary</a></td>


### PR DESCRIPTION
Algorithms DFS and BFS are primarily for graphs. Time and space complexities should be expressed in terms of the numbers of vertices |V| and the number of edges |E|.

The real complexity of DFS and BFS is O(|V| + |E|).
The time complexity for DFS and BFS given by Wikipedia makes the assumption that |E| > |V| and simplify |V| + |E| = O(|E|). But it's not always the case: if the graph has |V| = 1,000,000 vertices but just 10 edges, well DFS and BFS will have to go trough all the vertices before finishing, so it's certainly not O(|E|).

Most Computer Science books are reporting O(|E| + |V|) for DFS/BFS. See for example

> S. Dasgupta, C.H. Papadimitriou, and U.V. Vazirani, Algorithms
> (used at Berkeley and UC San Diego)
> see section 3.2.2. at http://www.cs.berkeley.edu/~vazirani/algorithms/chap3.pdf

or as well

> T. Cormen, C. Leiserson, R. Rivest, C. Stein, Introduction to Algorithms
> see section 22.2
