### PR TITLE
Remove a vertex in an adjacency list takes O(V+E)

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -271,7 +271,7 @@
 			<td><code class="yellow">O(|V|+|E|)</code></td>
 			<td><code class="green">O(1)</code></td>
 			<td><code class="green">O(1)</code></td>
-			<td><code class="yellow">O(|E|)</code></td>
+			<td><code class="yellow">O(|V| + |E|)</code></td>
 			<td><code class="yellow">O(|E|)</code></td>
 			<td><code class="yellow">O(|V|)</code></td>
 		</tr>


### PR DESCRIPTION
When removing a vertex u in a graph represented as an Adjacency List, you have to go through all the other vertices and check if they have an edge to u. This takes time O(|V| + |E|).

In the situation where |E| > |V|, then it can be simply in O(|E|). But it's not always true (for eg, |E| = 2 and |V| = 1,000,000).
