### PR TITLE
Added shortest path algorithms (Dijkstra + Bellman-Ford)

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -57,6 +57,30 @@
       <td><code class="red">O(n)</code></td>
       <td><code class="green">O(1)</code></td>
     </tr>
+    <tr>
+      <td><a href="http://en.wikipedia.org/wiki/Dijkstra's_algorithm">Shortest path by Dijkstra, using a Min-heap as priority queue</a></td>
+      <td>Graph with |V| vertices and |E| edges</td>
+      <td><code class="yellow">O((|V| + |E|) log |V|)</code></td>
+      <td><code class="yellow">O((|V| + |E|) log |V|)</code></td>
+      <td><code class="yellow">O((|V| + |E|) log |V|)</code></td>
+      <td><code class="yellow">O(|V|)</code></td>
+    </tr>
+    <tr>
+      <td><a href="http://en.wikipedia.org/wiki/Dijkstra's_algorithm">Shortest path by Dijkstra, using an unsorted array as priority queue</a></td>
+      <td>Graph with |V| vertices and |E| edges</td>
+      <td><code class="yellow">O(|V|^2)</code></td>
+      <td><code class="yellow">O(|V|^2)</code></td>
+      <td><code class="yellow">O(|V|^2)</code></td>
+      <td><code class="yellow">O(|V|)</code></td>
+    </tr>
+    <tr>
+      <td><a href="http://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm">Shortest path by Bellman-Ford</a></td>
+      <td>Graph with |V| vertices and |E| edges</td>
+      <td><code class="yellow">O(|V||E|)</code></td>
+      <td><code class="yellow">O(|V||E|)</code></td>
+      <td><code class="yellow">O(|V||E|)</code></td>
+      <td><code class="yellow">O(|V|)</code></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
The complexity of Dijsktra's algorithm changes according the priority queue implementation. I gave two implementation: Min-heap and Unsorted array. We can't say that one is better than the other:
- in **dense** graph, where |E| = O(|V|), **unsorted array** is better: it gives O(|V|^2) where Min-heap gives O(|V|^2 log n)
- in **sparse** graph, where |E| = O(|V|^2), **min-heap** is better: it gives O(|V| log |V|) where unsorted array gives O(|V|^2)
