### PR TITLE
Made the color coding for Data Structures' space complexity make sense

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -208,7 +208,7 @@
       <td><code class="red">O(n)</code></td>
 			<td><code>-</code></td>
       <td><code>-</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Dynamic_array">Dynamic Array</a></td>
@@ -220,7 +220,7 @@
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code>-</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Singly_linked_list#Singly_linked_lists">Singly-Linked List</a></td>
@@ -232,7 +232,7 @@
       <td><code class="red">O(n)</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="green">O(1)</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr> 
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Doubly_linked_list">Doubly-Linked List</a></td>
@@ -245,7 +245,7 @@
       <td><code class="red">O(n)</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="green">O(1)</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr> 
 	<tr>
       <td><a href="http://en.wikipedia.org/wiki/Skip_list">Skip List</a></td>
@@ -258,7 +258,7 @@
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
-	  <td><code class="yellow">O(n log(n))</code></td>
+	  <td><code class="red">O(n log(n))</code></td>
     </tr> 
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Hash_table">Hash Table</a></td>
@@ -270,7 +270,7 @@
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Binary_search_tree">Binary Search Tree</a></td>
@@ -282,7 +282,7 @@
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/B_tree">B-Tree</a></td>
@@ -294,7 +294,7 @@
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Red-black_tree">Red-Black Tree</a></td>
@@ -306,7 +306,7 @@
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/AVL_tree">AVL Tree</a></td>
@@ -318,7 +318,7 @@
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
-			<td><code class="red">O(n)</code></td>
+			<td><code class="yellow">O(n)</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Skip lists are the only data structure listed that use more than the minimum amount of memory needed to store the data (without compression).  Every other algorithm uses O(n) memory, but skip lists require O(n log(n)).

The others should all either be green with skip lists being yellow or they should all be yellow with skip lists being red.  I've proposed this second change.
