### PR TITLE
Fix some complexities.

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -109,7 +109,7 @@
       <td><code class="yellow">O(n log(n))</code></td>
       <td><code class="green">O(n log(n))</code></td>
       <td><code class="red">O(n^2)</code></td>
-      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Merge_sort">Mergesort</a></td>
@@ -215,11 +215,11 @@
       <td><code class="green">O(1)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
-      <td><code>-</code></td>
+      <td><code class="red">O(n)</code></td>
 			<td><code class="green">O(1)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
-      <td><code>-</code></td>
+      <td><code class="red">O(n)</code></td>
 			<td><code class="yellow">O(n)</code></td>
     </tr>
 		<tr>
@@ -250,7 +250,7 @@
 	<tr>
       <td><a href="http://en.wikipedia.org/wiki/Skip_list">Skip List</a></td>
 
-		<td><code class="red">O(n)</code></td>
+		<td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
@@ -274,11 +274,11 @@
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Binary_search_tree">Binary Search Tree</a></td>
-      <td><code>-</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
-			<td><code>-</code></td>
+      <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
@@ -286,11 +286,11 @@
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/B_tree">B-Tree</a></td>
-      <td><code>-</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
-			<td><code>-</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
@@ -298,11 +298,11 @@
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Red-black_tree">Red-Black Tree</a></td>
-      <td><code>-</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
-			<td><code>-</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
@@ -310,11 +310,11 @@
     </tr>
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/AVL_tree">AVL Tree</a></td>
-      <td><code>-</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
-			<td><code>-</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
       <td><code class="green">O(log(n))</code></td>
@@ -365,7 +365,7 @@
         </tr>
         <tr>
             <td><a href="http://en.wikipedia.org/wiki/Binary_heap">Binary Heap</a></td>
-            <td><code class="yellow">O(log(n))</code></td>
+            <td><code class="yellow">O(n)</code></td>
             <td><code class="green">O(1)</code></td>
             <td><code class="yellow">O(log(n))</code></td>
             <td><code class="yellow">O(log(n))</code></td>


### PR DESCRIPTION
Quicksort's worst-case uses a linear number of stack frames.
You can delete arbitrary elements of dynamic arrays, but it will take linear time to move stuff over after the delete.
Skip lists can support indexing in log time, as can all sorted trees.
Heapify takes linear time.
