### PR TITLE
Standardize application of color css classes

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -117,7 +117,7 @@
       <td><code class="yellow">O(n log(n))</code></td>
       <td><code class="green">O(n log(n))</code></td>
       <td><code class="green">O(n log(n))</code></td>
-      <td><code class="red">O(n)</code></td>
+      <td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Heapsort">Heapsort</a></td>

--- a/Tables.html
+++ b/Tables.html
@@ -251,9 +251,9 @@
       <td><a href="http://en.wikipedia.org/wiki/Skip_list">Skip List</a></td>
 
 		<td><code class="yellow">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
 		<td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
@@ -275,9 +275,9 @@
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Binary_search_tree">Binary Search Tree</a></td>
       <td><code class="yellow">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
@@ -287,9 +287,9 @@
    	<tr>
       <td><a href="https://en.wikipedia.org/wiki/Cartesian_tree">Cartresian Tree</a></td>
       <td><code>-</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
 			<td><code>-</code></td>
       <td><code class="red">O(n)</code></td>
       <td><code class="red">O(n)</code></td>
@@ -311,37 +311,37 @@
 		<tr>
       <td><a href="http://en.wikipedia.org/wiki/Red-black_tree">Red-Black Tree</a></td>
       <td><code class="yellow">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
       <td><code class="yellow">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
 			<td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
       <td><a href="https://en.wikipedia.org/wiki/Splay_tree">Splay Tree</a></td>
       <td><code>-</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
 			<td><code>-</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
       <td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/AVL_tree">AVL Tree</a></td>
       <td><code class="yellow">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
       <td><code class="yellow">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
-      <td><code class="green">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
 			<td><code class="yellow">O(n)</code></td>
     </tr>
   </tbody>


### PR DESCRIPTION
Assuming colors are intended to help with us quickly compare different algorithms or data structures, it seems like the color styling--though subjective--should be applied consistently within each column.  For example, mergesort and quicksort both have a worst-case O(n) running time, so they should have the same color styling applied.  I have fixed several small inconsistencies like this.

I think it would be better overall if there were more css classes for each complexity class (something like progressively darker shades for constant, linear, log-linear, quadratic, etc) so that styling was less subjective, but you haven't made the stylesheet available in this repo.