### PR TITLE
Quicksort's space complexity

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -109,7 +109,7 @@
       <td><code class="yellow">O(n log(n))</code></td>
       <td><code class="green">O(n log(n))</code></td>
       <td><code class="red">O(n^2)</code></td>
-      <td><code class="yellow">O(n)</code></td>
+      <td><code class="yellow">O(log(n))</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Merge_sort">Mergesort</a></td>


### PR DESCRIPTION
O(log(n)) instead of O(n)
http://stackoverflow.com/questions/12573330/why-does-quicksort-use-ologn-extra-space