### PR TITLE
updated average/worst case of shell sort

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -242,8 +242,8 @@
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Shellsort">Shell Sort</a></td>
       <td><code class="green">O(n)</code></td>
-      <td><code class="red">O((nlog(n))^2)</code></td>
-      <td><code class="red">O((nlog(n))^2)</code></td>
+      <td><code class="red">O(n(log(n))^2)</code></td>
+      <td><code class="red">O(n(log(n))^2)</code></td>
       <td><code class="green">O(1)</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
Was O( (n*log(n))^2 ) but wikipedia says that it is  O ( n*(log(n)^2 )