### PR TITLE
A binomial heap can be built in O(n) operations

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -366,7 +366,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Binomial_heap">Binomial Heap</a></td>
-      <td><code>-</code></td>
+      <td><code class="yellow">O(n)</code></td>
       <td><code rel="tooltip" title="With aux pointer" class="green">O(1)</code></td>
       <td><code class="yellow-green">O(log(n))</code></td>
       <td><code class="yellow-green">O(log(n))</code></td>


### PR DESCRIPTION
Merge trees by pairs until there is only one tree left. A bit like a bottom-up
mergesort where each merge operation costs 1 comparison.

For example, for 7 elements:
heap = [ ] , trees = [ x , x , x , x , x , x , x ]
heap = [ x ] , trees = [ x x , x x , x x ]
heap = [ x , x x ] , trees = [ x x x x ]
heap = [ x , x x , x x x x] , trees = [ ]

For 8 elements ( _ represents an empty tree ) :
heap = [ ] , trees = [ x , x , x , x , x , x , x , x ]
heap = [ _ , ] , trees = [ x x , x x , x x , x x ]
heap = [ _ , _ ] , trees = [ x x x x , x x x x ]
heap = [ _ , _ , _ ,] , trees = [ x x x x x x x x ]
heap = [ _ , _ , _ , x x x x x x x x ] , trees = [ ]

For 5 elements:
heap = [ ] , trees = [ x , x , x , x , x ]
heap = [ x ] , trees = [ x x , x x ]
heap = [ x , _ ] , trees = [ x x x x ]
heap = [ x , _ , x x x x] , trees = [ ]