### PR TITLE
Adds KD tree

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -170,6 +170,18 @@
       <td><code class="yellow-green">O(log(n))</code></td>
       <td><code class="yellow">O(n)</code></td>
     </tr>
+    <tr>
+      <td><a href="http://en.wikipedia.org/wiki/K-d_tree">KD Tree</a></td>
+      <td><code class="yellow-green">O(log(n))</code></td>
+      <td><code class="yellow-green">O(log(n))</code></td>
+      <td><code class="yellow-green">O(log(n))</code></td>
+      <td><code class="yellow-green">O(log(n))</code></td>
+      <td><code class="yellow">O(n)</code></td>
+      <td><code class="yellow">O(n)</code></td>
+      <td><code class="yellow">O(n)</code></td>
+      <td><code class="yellow">O(n)</code></td>
+      <td><code class="yellow">O(n)</code></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
This tree is used for representing k-dimensional spatial data. Point
clouds are commonly represented using 2d or 3d variants of this
structure.

The key benefit is for k-nearest neighbor search but as there is no way
to indicate the complexity of that specific operation, I've just added
the nominal complexities for single element access/insert/delete, etc.

Additionally, while balanced kd-trees are certainly possible, I'm only
putting the complexity values of the nominal kd-tree structure which
have O(n) worst case time complexities for all listed operations.