### PR TITLE
fix shellsort analysis

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -240,10 +240,10 @@
       <td><code class="green">O(1)</code></td>
     </tr>
     <tr>
-      <td><a href="http://en.wikipedia.org/wiki/Shellsort">Shell Sort</a></td>
-      <td><code class="green">O(n)</code></td>
-      <td><code class="red">O((nlog(n))^2)</code></td>
-      <td><code class="red">O((nlog(n))^2)</code></td>
+      <td><a href="http://en.wikipedia.org/wiki/Shellsort">Shell Sort</a><a href="http://www.cs.wcupa.edu/rkline/ds/shell-comparison.html"><code>(h=2^k-1)</code></a></td>
+      <td><code class="green">O(n log(n))</code></td>
+      <td><code class="red">O(n^1.25)</code> conjectured</td>
+      <td><code class="red">O(n^(3/2))</code></td>
       <td><code class="green">O(1)</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
shellsort needs reference to a specific h-sequence otherwise the complexity varies tremendously. So used the h-sequence that wikipedia cites in their table: http://www.cs.wcupa.edu/rkline/ds/shell-comparison.html.
Also the original table should be n (log(n))^2 not (nlog(n))^2.