### PR TITLE
Changed worst case time complexities for linked lists to O(n)

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -69,8 +69,8 @@
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="yellow">O(n)</code></td>
       <td><code class="yellow">O(n)</code></td>
-      <td><code class="green">O(1)</code></td>
-      <td><code class="green">O(1)</code></td>
+      <td><code class="yellow">O(n)</code></td>
+      <td><code class="yellow">O(n)</code></td>
       <td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
@@ -81,8 +81,8 @@
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="yellow">O(n)</code></td>
       <td><code class="yellow">O(n)</code></td>
-      <td><code class="green">O(1)</code></td>
-      <td><code class="green">O(1)</code></td>
+      <td><code class="yellow">O(n)</code></td>
+      <td><code class="yellow">O(n)</code></td>
       <td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
The worst case time complexities of the linked lists seem a little misleading. If you don't know the location you want to insert/delete at, then you need to traverse the list, therefore taking O(n).
Maybe some asterisk with comments would be a good approach for fields like this.