### PR TITLE
Remove disambiguation of average/worst cases with landau theta/oh notation

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -8,12 +8,6 @@
     </tr>
     <tr>
       <th></th>
-      <th colspan="4">Average</th>
-      <th colspan="4">Worst</th>
-      <th>Worst</th>
-    </tr>
-    <tr>
-      <th></th>
       <th>Access</th>
       <th>Search</th>
       <th>Insertion</th>
@@ -202,13 +196,6 @@
       <th>Algorithm</th>
       <th colspan="3">Time Complexity</th>
       <th>Space Complexity</th>
-    </tr>
-    <tr>
-      <th></th>
-      <th>Best</th>
-      <th>Average</th>
-      <th>Worst</th>
-      <th>Worst</th>
     </tr>
 
     <tr>


### PR DESCRIPTION
Average/worst/best cases represent specific runtimes based on the input. Landau notation represents asymptotic bounds as the input approaches infinity. Associating average/worst cases with the theta/O notations is confusing and reinforces ambiguation.