### PR TITLE
remove access time complexity for trees and abstract data types

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -39,7 +39,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Stack_(abstract_data_type)">Stack</a></td>
-      <td><code class="yellow">&Theta;(n)</code></td>
+      <td><code class="yellow">N/A</code></td>
       <td><code class="yellow">&Theta;(n)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
@@ -51,7 +51,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Queue_(abstract_data_type)">Queue</a></td>
-      <td><code class="yellow">&Theta;(n)</code></td>
+      <td><code class="yellow">N/A</code></td>
       <td><code class="yellow">&Theta;(n)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
@@ -111,7 +111,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Binary_search_tree">Binary Search Tree</a></td>
-      <td><code class="yellow-green">&Theta;(log(n))</code></td>
+      <td><code class="yellow-green">N/A</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
@@ -135,7 +135,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/B_tree">B-Tree</a></td>
-      <td><code class="yellow-green">&Theta;(log(n))</code></td>
+      <td><code class="yellow-green">N/A</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">O(log(n))</code></td>
@@ -147,7 +147,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Red-black_tree">Red-Black Tree</a></td>
-      <td><code class="yellow-green">&Theta;(log(n))</code></td>
+      <td><code class="yellow-green">N/A</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
@@ -171,7 +171,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/AVL_tree">AVL Tree</a></td>
-      <td><code class="yellow-green">&Theta;(log(n))</code></td>
+      <td><code class="yellow-green">N/A</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
@@ -183,7 +183,7 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/K-d_tree">KD Tree</a></td>
-      <td><code class="yellow-green">&Theta;(log(n))</code></td>
+      <td><code class="yellow-green">N/A</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>
       <td><code class="yellow-green">&Theta;(log(n))</code></td>


### PR DESCRIPTION
I guess "access" in the table means `array[i]`.

Like hash tables, I don't think there is an access operation for trees.
Besides, stack and queue are abstract data types and they don't have this operation.

There is a preview of my change.
https://crvv.github.io/BigOCheatSheet/Tables.html