### PR TITLE
Changed Complexity to Efficiency

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -3,8 +3,8 @@
 
     <tr>
       <th>Data Structure</th>
-      <th colspan="8">Time Complexity</th>
-      <th>Space Complexity</th>
+      <th colspan="8">Time Efficiency</th>
+      <th>Space Efficiency</th>
     </tr>
     <tr>
       <th></th>
@@ -200,8 +200,8 @@
 <table class="table table-bordered table-striped">
     <tr>
       <th>Algorithm</th>
-      <th colspan="3">Time Complexity</th>
-      <th>Space Complexity</th>
+      <th colspan="3">Time Efficiency</th>
+      <th>Space Efficiency</th>
     </tr>
     <tr>
       <th></th>


### PR DESCRIPTION
Changed "Complexity" to "Efficiency", because Big O Notation is a way to measure an algorithm's efficiency.

Big-O classes should not be confused with the actual complexity classes (= P, QP, DLOGTIME, NP, PSPACE,...). Both Big-O and complexity classes are part of Computational Complexity Theory in computer science, thus, "complexity" is half right (but still wrong to some degree). This might seem minor and philosophical, but the terminology can be very confusing for beginners. Please accept this rephrasing in the table headings, it is important to university teaching.