### PR TITLE
Update Tables.html: Correction for Quick Sort worst-case space comple…

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -216,7 +216,7 @@
       <td><code class="orange">&Omega;(n log(n))</code></td>
       <td><code class="orange">&Theta;(n log(n))</code></td>
       <td><code class="red">O(n^2)</code></td>
-      <td><code class="yellow-green">O(log(n))</code></td>
+      <td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Merge_sort">Mergesort</a></td>


### PR DESCRIPTION
…xity

The worst-case space complexity of the Quick Sort Algorithm is not O(log(n)). In the worst-case scenario, Quick Sort has a space complexity of O(n) due to the potentially unbalanced partitioning. If the pivot chosen at each step consistently divides the array in an unbalanced manner, it can lead to a recursion depth of 'n,' resulting in O(n) space complexity.