### PR TITLE
corrected time complexity of Stack and Queue Access and Search Operations

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -39,11 +39,11 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Stack_(abstract_data_type)">Stack</a></td>
-      <td><code class="yellow">&Theta;(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="yellow">&Theta;(n)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
-      <td><code class="yellow">O(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="yellow">O(n)</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="green">O(1)</code></td>
@@ -51,11 +51,11 @@
     </tr>
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Queue_(abstract_data_type)">Queue</a></td>
-      <td><code class="yellow">&Theta;(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="yellow">&Theta;(n)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
-      <td><code class="yellow">O(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="yellow">O(n)</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="green">O(1)</code></td>

--- a/Tables.html
+++ b/Tables.html
@@ -40,11 +40,11 @@
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Stack_(abstract_data_type)">Stack</a></td>
       <td><code class="gray">N/A</code></td>
-      <td><code class="yellow">&Theta;(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="gray">N/A</code></td>
-      <td><code class="yellow">O(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="yellow">O(n)</code></td>
@@ -52,11 +52,11 @@
     <tr>
       <td><a href="http://en.wikipedia.org/wiki/Queue_(abstract_data_type)">Queue</a></td>
       <td><code class="gray">N/A</code></td>
-      <td><code class="yellow">&Theta;(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="green">&Theta;(1)</code></td>
       <td><code class="gray">N/A</code></td>
-      <td><code class="yellow">O(n)</code></td>
+      <td><code class="gray">N/A</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="green">O(1)</code></td>
       <td><code class="yellow">O(n)</code></td>


### PR DESCRIPTION
🔄 **Pull Request: Update Time Complexity for Stack and Queue Access and Search Operations**

**Changes Proposed:**
In this pull request, I propose updating the time complexity for accessing and searching elements within the Stack and Queue to be marked as N/A. 

**Details:**
- **Old Documentation:**
  - Stack and Queue access and search operations were previously O(N) .
- **Proposed Documentation:**
  - Updated the time complexity to N/A.


Note: While accessing the top element is a constant time operation and we might be able to search or access with several `peek()`  operations in O(n) time complexity but it's not supported by both stack and queue ADT.
