### PR TITLE
Fix: change CSS class of O(n+k) and O(n) to yellow (it is not better than O(n) wich is yellow)

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -276,23 +276,23 @@
     </tr>
     <tr>
       <td><a rel="tooltip" title="Only for integers. k is a number of buckets" href="http://en.wikipedia.org/wiki/Bucket_sort">Bucket Sort</a></td>
-      <td><code class="green">&Omega;(n+k)</code></td>
-      <td><code class="green">&Theta;(n+k)</code></td>
+      <td><code class="yellow">&Omega;(n+k)</code></td>
+      <td><code class="yellow">&Theta;(n+k)</code></td>
       <td><code class="red">O(n^2)</code></td>
       <td><code class="yellow">O(n)</code></td>
     </tr>
     <tr>
       <td><a rel="tooltip" title="Constant number of digits 'k'" href="http://en.wikipedia.org/wiki/Radix_sort">Radix Sort</a></td>
-      <td><code class="green">&Omega;(nk)</code></td>
-      <td><code class="green">&Theta;(nk)</code></td>
-      <td><code class="green">O(nk)</code></td>
+      <td><code class="yellow">&Omega;(nk)</code></td>
+      <td><code class="yellow">&Theta;(nk)</code></td>
+      <td><code class="yellow">O(nk)</code></td>
       <td><code class="yellow">O(n+k)</code></td>
     </tr>
     <tr>
       <td><a rel="tooltip" title="Difference between maximum and minimum number 'k'" href="https://en.wikipedia.org/wiki/Counting_sort">Counting Sort</a></td>
-      <td><code class="green">&Omega;(n+k)</code></td>
-      <td><code class="green">&Theta;(n+k)</code></td>
-      <td><code class="green">O(n+k)</code></td>
+      <td><code class="yellow">&Omega;(n+k)</code></td>
+      <td><code class="yellow">&Theta;(n+k)</code></td>
+      <td><code class="yellow">O(n+k)</code></td>
       <td><code class="yellow">O(k)</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
- This pull request changes the CSS class for O(n+k) and O(n) to yellow to correctly represent their performance in the visual representation.
- O(n+k) was previously marked with a color indicating better performance than O(n), which is incorrect.