### PR TITLE
Add Pigeonhole and Bitonic Sort entries to table

### DIFF
--- a/Tables.html
+++ b/Tables.html
@@ -302,5 +302,20 @@
       <td><code class="orange">O(n log(n))</code></td>
       <td><code class="yellow">O(n)</code></td>
    </tr>
+    <tr>
+      <td><a rel="tooltip" title="Similar to counting sort but uses pigeonholes" href="https://en.wikipedia.org/wiki/Pigeonhole_sort">Pigeonhole Sort</a></td>
+      <td><code class="green">&Omega;(n + k)</code></td>
+      <td><code class="green">&Theta;(n + k)</code></td>
+      <td><code class="green">O(n + k)</code></td>
+      <td><code class="yellow">O(k)</code></td>
+    </tr>
+    <tr>
+      <td><a href="https://en.wikipedia.org/wiki/Bitonic_sorter">Bitonic Sort</a></td>
+      <td><code class="orange">&Omega;(n log^2 n)</code></td>
+      <td><code class="orange">&Theta;(n log^2 n)</code></td>
+      <td><code class="orange">O(n log^2 n)</code></td>
+      <td><code class="yellow">O(n log^2 n)</code></td>
+    </tr>
+
 
 </table>


### PR DESCRIPTION
This pull introduces two additional sorting algorithms to the complexity comparison table:

Bitonic Sort

Counting Sort variation — Pigeonhole Sort

Both entries include time complexities, space complexities, and official references. The new rows match the formatting that already used in the table.